### PR TITLE
Add support for `tar` on Windows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ runs:
   steps:
     - name: Archive artifact
       shell: bash
+      if: runner.os != 'Windows'
       run: |
         tar \
           --dereference --hard-dereference \
@@ -22,6 +23,21 @@ runs:
           --exclude=.git \
           --exclude=.github \
           .
+
+    # Massage the paths for Windows only
+    - name: Archive artifact
+      shell: bash
+      if: runner.os == 'Windows'
+      run: |
+        tar \
+          --dereference --hard-dereference \
+          --directory "${{ inputs.path }}" \
+          -cvf "${{ runner.temp }}\artifact.tar" \
+          --exclude=.git \
+          --exclude=.github \
+          --force-local \
+          "."
+
     - name: Upload artifact
       uses: actions/upload-artifact@main
       with:


### PR DESCRIPTION
This should address https://github.com/actions/upload-pages-artifact/issues/4.

On Windows we need to "massage" a bit file paths because we use git shell there. I added double quotes everywhere, backslashes where we explicitly join paths and the `--force-local` option (see why [here](https://steve-parker.org/linux/tar-colon-filename/)).

Validation: https://github.com/yoannchaudet/upload-pages-artifact/runs/7612664027?check_suite_focus=true