### PR TITLE
Add support for macOS-based workflows

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,23 @@ runs:
   steps:
     - name: Archive artifact
       shell: bash
-      if: runner.os != 'Windows'
+      if: runner.os == 'Linux'
       run: |
         tar \
           --dereference --hard-dereference \
+          --directory ${{ inputs.path }} \
+          -cvf ${{ runner.temp }}/artifact.tar \
+          --exclude=.git \
+          --exclude=.github \
+          .
+
+    # Remove the --hard-dereference option for macOS only
+    - name: Archive artifact
+      shell: bash
+      if: runner.os == 'macOS'
+      run: |
+        tar \
+          --dereference \
           --directory ${{ inputs.path }} \
           -cvf ${{ runner.temp }}/artifact.tar \
           --exclude=.git \

--- a/action.yml
+++ b/action.yml
@@ -24,13 +24,13 @@ runs:
           --exclude=.github \
           .
 
-    # Remove the --hard-dereference option for macOS only
+    # Switch to gtar (GNU tar instead of bsdtar which is the default in the MacOS runners so we can use --hard-dereference)
     - name: Archive artifact
       shell: bash
       if: runner.os == 'macOS'
       run: |
-        tar \
-          --dereference \
+        gtar \
+          --dereference --hard-dereference \
           --directory ${{ inputs.path }} \
           -cvf ${{ runner.temp }}/artifact.tar \
           --exclude=.git \


### PR DESCRIPTION
Using this action on macOS will throw the following error: 

```
tar: Option --hard-dereference is not supported
Usage:
  List:    tar -tf <archive-filename>
  Extract: tar -xf <archive-filename>
  Create:  tar -cf <archive-filename> [filenames...]
  Help:    tar --help
```
