### PR TITLE
Rename to include "GitHub" in "GitHub Pages" for Marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
 name: "Upload GitHub Pages artifact"
 description: "A composite action that prepares your static assets to be deployed to GitHub Pages"
+author: "GitHub"
 inputs:
   path:
     description: "Path of the directory containing the static assets."

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: "Upload Pages artifact"
+name: "Upload GitHub Pages artifact"
 description: "A composite action that prepares your static assets to be deployed to GitHub Pages"
 inputs:
   path:


### PR DESCRIPTION
Upon recommendation from `@chrispat`, we should rename our published Action's name to include "GitHub" in "GitHub Pages" on the Marketplace.