### PR TITLE
Handle weird input paths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,6 @@ runs:
           .
       env:
         INPUT_PATH: ${{ inputs.path }}
-        RUNNER_TEMP: ${{ runner.temp }}
 
     # Switch to gtar (GNU tar instead of bsdtar which is the default in the MacOS runners so we can use --hard-dereference)
     - name: Archive artifact
@@ -42,7 +41,6 @@ runs:
           .
       env:
         INPUT_PATH: ${{ inputs.path }}
-        RUNNER_TEMP: ${{ runner.temp }}
 
     # Massage the paths for Windows only
     - name: Archive artifact
@@ -59,7 +57,6 @@ runs:
           "."
       env:
         INPUT_PATH: ${{ inputs.path }}
-        RUNNER_TEMP: ${{ runner.temp }}
 
     - name: Upload artifact
       uses: actions/upload-artifact@main

--- a/action.yml
+++ b/action.yml
@@ -19,11 +19,14 @@ runs:
       run: |
         tar \
           --dereference --hard-dereference \
-          --directory ${{ inputs.path }} \
-          -cvf ${{ runner.temp }}/artifact.tar \
+          --directory "$INPUT_PATH" \
+          -cvf "$RUNNER_TEMP/artifact.tar" \
           --exclude=.git \
           --exclude=.github \
           .
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        RUNNER_TEMP: ${{ runner.temp }}
 
     # Switch to gtar (GNU tar instead of bsdtar which is the default in the MacOS runners so we can use --hard-dereference)
     - name: Archive artifact
@@ -32,11 +35,14 @@ runs:
       run: |
         gtar \
           --dereference --hard-dereference \
-          --directory ${{ inputs.path }} \
-          -cvf ${{ runner.temp }}/artifact.tar \
+          --directory "$INPUT_PATH" \
+          -cvf "$RUNNER_TEMP/artifact.tar" \
           --exclude=.git \
           --exclude=.github \
           .
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        RUNNER_TEMP: ${{ runner.temp }}
 
     # Massage the paths for Windows only
     - name: Archive artifact
@@ -45,12 +51,15 @@ runs:
       run: |
         tar \
           --dereference --hard-dereference \
-          --directory "${{ inputs.path }}" \
-          -cvf "${{ runner.temp }}\artifact.tar" \
+          --directory "$INPUT_PATH" \
+          -cvf "$RUNNER_TEMP\artifact.tar" \
           --exclude=.git \
           --exclude=.github \
           --force-local \
           "."
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        RUNNER_TEMP: ${{ runner.temp }}
 
     - name: Upload artifact
       uses: actions/upload-artifact@main


### PR DESCRIPTION
I saw a recent blog post by Joren Vrancken about a [command injection vulnerability in the GH Pages build pipeline](https://blog.nietaanraken.nl/posts/github-pages-command-injection/). A small code snippet from this repo was shared, which showed how the input path provided to this action was not being escaped. This action could be triggered by an HTTP endpoint used when changing Jekyll themes, which is ultimately what led to the vulnerability.

The vulnerability has since been resolved by disabling the Jekyll theme picker in the UI (and the associated HTTP endpoint), but the underlying bug in this action still exists: paths are still interpolated directly in a shell script instead of being quoted or escaped properly. Practically speaking, this means that this action doesn't allow input paths with spaces or quotes.

This PR fixes that bug by passing the input paths as an env var, rather than interpolating the string in the shell script directly. I even set up some test repositories to exercise this, so now even repo layouts with weird path names work, including spaces and double quotes.
