### PR TITLE
Add exclude option

### DIFF
--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -32,6 +32,11 @@ jobs:
       uses: ./
       with:
         path: artifact
+        exclude: ./excludeddir
+
+    - name: Remove exclude files
+      run: rm -rf artifact/excludeddir
+      shell: bash
 
     - name: Download artifact
       uses: actions/download-artifact@v3

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "Path of the directory containing the static assets."
     required: true
     default: "_site/"
+  exclude:
+    description: "Pattern of exclude files from the assets."
+    required: false
+    default: ""
   retention-days:
     description: "Duration after which artifact will expire in days."
     required: false
@@ -23,6 +27,7 @@ runs:
           -cvf ${{ runner.temp }}/artifact.tar \
           --exclude=.git \
           --exclude=.github \
+          ${{ (inputs.exclude == '') && ' ' || format('--exclude {0}', inputs.exclude ) }} \
           .
 
     # Switch to gtar (GNU tar instead of bsdtar which is the default in the MacOS runners so we can use --hard-dereference)
@@ -36,6 +41,7 @@ runs:
           -cvf ${{ runner.temp }}/artifact.tar \
           --exclude=.git \
           --exclude=.github \
+          ${{ (inputs.exclude == '') && ' ' || format('--exclude {0}', inputs.exclude ) }} \
           .
 
     # Massage the paths for Windows only
@@ -49,6 +55,7 @@ runs:
           -cvf "${{ runner.temp }}\artifact.tar" \
           --exclude=.git \
           --exclude=.github \
+          ${{ (inputs.exclude == '') && ' ' || format('--exclude {0}', inputs.exclude ) }} \
           --force-local \
           "."
 

--- a/script/new-artifact.sh
+++ b/script/new-artifact.sh
@@ -4,6 +4,8 @@
 echo 'hello' > hello.txt
 mkdir subdir
 echo 'world' > subdir/world.txt
+mkdir excludeddir
+echo 'excluded' > excludeddir/excluded.txt
 
 # Add some symlinks (which we should dereference properly when archiving)
 ln -s subdir subdir-link


### PR DESCRIPTION
Add `exclude` input parameter for tar option `--exclude`.

Assuming a project using npm, we do not want to include `node_modules` files in the tar.
This change make it possible by the followings
```yml
- name: Install dependencies
  run: npm ci

- name: Build
  run: npm run build

- name: Upload artifacts
  uses: actions/upload-pages-artifact
  with:
    path: .
    exclude: node_modules
```