### PR TITLE
Before tarring site, set file read permissions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,7 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
+        chmod -R +r .
         tar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \
@@ -32,6 +33,7 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
+        chmod -R +r .
         gtar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
-        for f in $(chmod -v -R +r)
+        for f in $(chmod -v -R +r .)
         do
           echo "::warning::Added read permission to $f"
         done

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
-        for f in $(gchmod -c -R +r . | awk '{print substr($3, 2, length($3)-2)}')
+        for f in $(chmod -v -R +r)
         do
           echo "::warning::Added read permission to $f"
         done

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,10 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
-        chmod -R +r .
+        for f in $(chmod -c -R +r . | awk '{print substr($3, 2, length($3)-2)}')
+        do
+          echo "::warning::Added read permission to $f"
+        done
         tar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \
@@ -33,7 +36,10 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
-        chmod -R +r .
+        for f in $(gchmod -c -R +r . | awk '{print substr($3, 2, length($3)-2)}')
+        do
+          echo "::warning::Added read permission to $f"
+        done
         gtar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \


### PR DESCRIPTION
Adds read permission before tarring to prevent unreadable files from being deployed. This only affects files that are built on an actions runner, not files that are cloned from a git repoitory, because git's permissions are limited to the equivalents of chmod 644 and 755.

Uses `gchmod` on mac to conform with `chmod` on gnu/linux.