### PR TITLE
Update to latest `actions/publish-action`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Update the ${{ env.TAG_NAME }} tag
         id: update-major-tag
-        uses: actions/publish-action@v0.1.0
+        uses: actions/publish-action@v0.2.1
         with:
           source-tag: ${{ env.TAG_NAME }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
To avoid Actions core deprecation messages.

https://github.com/actions/publish-action/releases/tag/v0.2.1