### PR TITLE
Print warnings about changed file permissions in bulk

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,8 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
-        for f in $(chmod -c -R +r . | awk '{print substr($3, 2, length($3)-2)}')
-        do
-          echo "::warning::Added read permission to $f"
+        chmod -c -R +r . | while read line; do
+          echo "::warning title=Changed permissions on a file::$line"
         done
         tar \
           --dereference --hard-dereference \
@@ -36,9 +35,8 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
-        for f in $(chmod -v -R +r .)
-        do
-          echo "::warning::Added read permission to $f"
+        chmod -v -R +r . | while read line; do
+          echo "::warning title=Changed permissions on a file::$line"
         done
         gtar \
           --dereference --hard-dereference \


### PR DESCRIPTION
Per a report in https://github.com/actions/upload-pages-artifact/pull/38, this will avoid mangled output when file names have spaces or other special characters within them.

Output looks like this:

On macos
<img width="314" alt="Screen Shot 2022-11-30 at 10 28 51 AM" src="https://user-images.githubusercontent.com/5176286/204840076-ac305874-a1d1-48f1-8981-53dba98104d3.png">

On linux
<img width="755" alt="Screen Shot 2022-11-30 at 10 31 09 AM" src="https://user-images.githubusercontent.com/5176286/204840086-44529f53-dd5c-49b0-9867-2098cafd0039.png">
