### PR TITLE
Fix link to releases in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The scripts and documentation in this project are released under the [MIT Licens
 
 <!-- references -->
 [pages]: https://pages.github.com
-[release-list]: ../../releases
+[release-list]: https://github.com/actions/upload-pages-artifact/releases
 [draft-release]: .github/workflows/draft-release.yml
 [release]: .github/workflows/release.yml
 [release-workflow-runs]: /actions/workflows/release.yml

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The scripts and documentation in this project are released under the [MIT Licens
 
 <!-- references -->
 [pages]: https://pages.github.com
-[release-list]: /releases
+[release-list]: ../../releases
 [draft-release]: .github/workflows/draft-release.yml
 [release]: .github/workflows/release.yml
 [release-workflow-runs]: /actions/workflows/release.yml


### PR DESCRIPTION
The current link in the README points to `https://github.com/actions/upload-pages-artifact/blob/main/releases`, which doesn't exist.