### PR TITLE
Fail if no artifact file is found to upload

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,3 +74,4 @@ runs:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/artifact.tar
         retention-days: ${{ inputs.retention-days }}
+        if-no-files-found: error

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
         INPUT_PATH: ${{ inputs.path }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@main
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/artifact.tar


### PR DESCRIPTION
Fixes #24

For more info, see: https://github.com/actions/upload-artifact#customization-if-no-files-are-found

**Update:** Also lock in at `actions/upload-artifact@v3` instead of `@main` to prevent us from consuming potential future breaking changes