### PR TITLE
Use absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ The scripts and documentation in this project are released under the [MIT Licens
 [release-list]: https://github.com/actions/upload-pages-artifact/releases
 [draft-release]: .github/workflows/draft-release.yml
 [release]: .github/workflows/release.yml
-[release-workflow-runs]: /actions/workflows/release.yml
+[release-workflow-runs]: https://github.com/actions/upload-pages-artifact/actions/workflows/release.yml
 [gzip]: https://en.wikipedia.org/wiki/Gzip
 [tar]: https://en.wikipedia.org/wiki/Tar_(computing)


### PR DESCRIPTION
If you visit: https://github.com/actions/upload-pages-artifact/blob/main/README.md#release-instructions
And click the last link:

> ⚠️ Environment approval is required. Check the [Release workflow run list](https://github.com/actions/upload-pages-artifact/blob/main/actions/workflows/release.yml).

You get sent to: https://github.com/actions/upload-pages-artifact/blob/main/actions/workflows/release.yml

<img width="484" alt="image" src="https://github.com/actions/upload-pages-artifact/assets/2119212/c2b6fa81-188b-4fac-b4cf-04933283df2d">

404 - page not found
The 
main

 branch of 
upload-pages-artifact

 does not contain the path 
actions/workflows/release.yml.

