### PR TITLE
Chmod delete

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,6 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
-        while read line; do
-          echo "::warning title=Invalid file permissions automatically fixed::$line"
-        done
         tar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \
@@ -39,9 +36,6 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
-        while read line; do
-          echo "::warning title=Invalid file permissions automatically fixed::$line"
-        done
         gtar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
-        chmod -c -R +rX "$INPUT_PATH" | while read line; do
+        while read line; do
           echo "::warning title=Invalid file permissions automatically fixed::$line"
         done
         tar \
@@ -39,7 +39,7 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
-        chmod -v -R +rX "$INPUT_PATH" | while read line; do
+        while read line; do
           echo "::warning title=Invalid file permissions automatically fixed::$line"
         done
         gtar \


### PR DESCRIPTION
part of: https://github.com/github/pages-engineering/issues/2428
Removing `chmod` since it tends to slow down deploys. Instead we going to trust by default that the user will have correct file permissions. If this is not the case then we will raise an error from our deployment side and flag file permissions as being a possible culprit. 