### PR TITLE
Revert `chmod` removal for `v1`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
+        chmod -c -R +rX "$INPUT_PATH" | while read line; do
+          echo "::warning title=Invalid file permissions automatically fixed::$line"
+        done
         tar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \
@@ -36,6 +39,9 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
+        chmod -v -R +rX "$INPUT_PATH" | while read line; do
+          echo "::warning title=Invalid file permissions automatically fixed::$line"
+        done
         gtar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \


### PR DESCRIPTION
Temporarily revert PR:
- #63

It represents a breaking change that we should move into a `v2.0.0` release.

Context: an accurate criticism from user @onbjerg in the `deploy-pages` action repo:
- https://github.com/actions/deploy-pages/issues/188#issuecomment-1597637940

> ...although I feel like this should have been a breaking version bump on `@actions/upload-pages-artifact`? 😄
