### PR TITLE
Re-remove built-in `chmod` commands for `v2`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,6 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
-        chmod -c -R +rX "$INPUT_PATH" | while read line; do
-          echo "::warning title=Invalid file permissions automatically fixed::$line"
-        done
         tar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \
@@ -39,9 +36,6 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
-        chmod -v -R +rX "$INPUT_PATH" | while read line; do
-          echo "::warning title=Invalid file permissions automatically fixed::$line"
-        done
         gtar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \


### PR DESCRIPTION
Reapply PR for `v2`:
- #63 

Re-reverts PR:
- #68 

Links:
- Closes https://github.com/actions/upload-pages-artifact/issues/45
- Closes https://github.com/actions/upload-pages-artifact/issues/48


:warning: Must be release as `v2.0.0` and `v2` as this is a breaking change! :warning:
