### PR TITLE
Upload pages artifact with upload-artifact v4-beta

### DIFF
--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Upload Pages artifact
       uses: ./
       with:
+        name: pages-artifact ${{ matrix.os }}
         path: artifact
 
     - name: Download artifact

--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -31,13 +31,13 @@ jobs:
     - name: Upload Pages artifact
       uses: ./
       with:
-        name: pages-artifact ${{ matrix.os }}
+        name: pages-artifact-${{ matrix.os }}
         path: artifact
 
     - name: Download artifact
       uses: actions/download-artifact@v4-beta
       with:
-          name: pages-artifact ${{ matrix.os }}
+          name: pages-artifact-${{ matrix.os }}
           path: artifact2
 
     - name: Extract artifact

--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Download artifact
       uses: actions/download-artifact@v4-beta
       with:
-          name: github-pages
+          name: pages-artifact ${{ matrix.os }}
           path: artifact2
 
     - name: Extract artifact

--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -34,7 +34,7 @@ jobs:
         path: artifact
 
     - name: Download artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4-beta
       with:
           name: github-pages
           path: artifact2

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
     default: "1"
 outputs:
-  artifact-id:
+  artifact_id:
     description: "The ID of the artifact that was uploaded."
     value: ${{ steps.upload-artifact.outputs.artifact-id }}
 runs:

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "Duration after which artifact will expire in days."
     required: false
     default: "1"
+outputs:
+  artifact-id:
+    description: "The ID of the artifact that was uploaded."
+    value: ${{ steps.upload-artifact.outputs.artifact-id }}
 runs:
   using: composite
   steps:
@@ -63,7 +67,8 @@ runs:
         INPUT_PATH: ${{ inputs.path }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      id: upload-artifact
+      uses: actions/upload-artifact@v4-beta
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/artifact.tar


### PR DESCRIPTION
## Overview

Closes https://github.com/github/actions-results-team/issues/1987

We have a `v4-beta` [branch](https://github.com/actions/upload-artifact/tree/v4-beta) of upload-artifact that we are starting to use internally. Note that it only works for select repositories that have the necessary feature flags enabled.

One of the main differences between v1-v3 upload-artifact and v4 is that the artifact will become available immediately in the UI and the artifact ID will also immediately be available as a step output. See https://github.com/actions/upload-artifact/blob/aa5cae10db2b39d79f5244f6bc5084278993a3ae/action.yml#L26-L31

We need to output the artifact ID so that we can use it later in the pages deployment flow.

## Testing

See https://github.com/bbq-beets/testing-artifacts-v4/actions/runs/6658237875 for an E2E flow.

With a workflow file such as this we are able to successfully output and display the artifact ID in another job. Long term this ID will be used as input to create a deployment.

```
jobs:
  build:
    runs-on: ubuntu-latest
    outputs:
      artifact-id: ${{ steps.upload-pages-artifact.outputs.artifact-id }}
    steps:
      - uses: actions/checkout@v3
      - name: Build
        uses: actions/jekyll-build-pages@v1
      - name: Upload Pages artifact
        id: upload-pages-artifact
        uses: konradpabjan/upload-pages-artifact@main

  job2:
    runs-on: ubuntu-latest
    needs: build
    steps:          
      - name: Display Artifact ID
        env:
            OUTPUT1: ${{needs.build.outputs.artifact-id}}
        run: |
          echo "Artifact ID from previous job is $OUTPUT1"
```

![image](https://github.com/actions/upload-pages-artifact/assets/16109154/eedbc688-556a-4216-9fe7-dcf6d8914977)

