### PR TITLE
Use `v4` upload-artifact tag

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
 
     - name: Upload artifact
       id: upload-artifact
-      uses: actions/upload-artifact@v4-beta
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/artifact.tar


### PR DESCRIPTION
Artifacts v4 have been GA'd:
- https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available

We should use that tag going forward!