### PR TITLE
Group tar's output to prevent it from messing up action logs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,7 @@ runs:
       shell: sh
       if: runner.os == 'Linux'
       run: |
+        echo ::group::Archive artifact
         tar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \
@@ -32,6 +33,7 @@ runs:
           --exclude=.git \
           --exclude=.github \
           .
+        echo ::endgroup::
       env:
         INPUT_PATH: ${{ inputs.path }}
 
@@ -40,6 +42,7 @@ runs:
       shell: sh
       if: runner.os == 'macOS'
       run: |
+        echo ::group::Archive artifact
         gtar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \
@@ -47,6 +50,7 @@ runs:
           --exclude=.git \
           --exclude=.github \
           .
+        echo ::endgroup::
       env:
         INPUT_PATH: ${{ inputs.path }}
 
@@ -55,6 +59,7 @@ runs:
       shell: bash
       if: runner.os == 'Windows'
       run: |
+        echo ::group::Archive artifact
         tar \
           --dereference --hard-dereference \
           --directory "$INPUT_PATH" \
@@ -63,6 +68,7 @@ runs:
           --exclude=.github \
           --force-local \
           "."
+        echo ::endgroup::
       env:
         INPUT_PATH: ${{ inputs.path }}
 


### PR DESCRIPTION
Hello maintainers, Please let me know if this PR is unreasonable.

When running a GitHub workflow, outputs of an action will be automatically grouped by step, but when an action is used as a component of another composite action, outputs from different components have no difference, so authors often use `echo ::group::Foo` and `echo ::endgroup::` to distinguish them.

So when this action is used in composite action (in this case, it is  [sphinx-notes/pages](https://github.com/sphinx-notes/pages/)), the output of `tar` command messes up logs (especially when there are many files to be archived).

For example: 

![火狐截图_2024-02-02T13-15-50 318Z](https://github.com/actions/upload-pages-artifact/assets/8090459/ebb86432-e5ea-4840-948f-55db371925b2) (The remaining two thousand lines are not displayed…)

So I patch this action, re-run the job, and everything goes well.

In addition, maybe the IO flush policy of grouped messages is different, and the running duration is accelerated by 1 minute. 

- [Job attempts #2](https://github.com/SilverRainZ/silverrainz.github.io/actions/runs/7755829399/attempts/2), the original action, 2m13s
- [Job attempts #3](https://github.com/SilverRainZ/silverrainz.github.io/actions/runs/7755829399/attempts/3), the patched action, 1m27s
