### PR TITLE
ignore all hidden files when creating zip

### DIFF
--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -51,3 +51,7 @@ jobs:
     - name: Check for absence of symlinks
       run: if [ $(find artifact2 -type l | wc -l) != 0 ]; then echo "Symlinks found"; exit 1; fi
       shell: bash
+
+    - name: Check for absence of hidden files
+      run: if [ $(find artifact2 -regex ".*/\..*" | wc -l) != 0 ]; then echo "Hidden files found"; exit 1; fi
+      shell: bash

--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -44,14 +44,16 @@ jobs:
       run: tar -xf artifact2/artifact.tar -C artifact2 && rm artifact2/artifact.tar
       shell: bash
 
+    - name: Check for absence of hidden files
+      run: if [ $(find artifact2 -regex ".*/\..*" | wc -l) != 0 ]; then echo "Hidden files found"; exit 1; fi
+      shell: bash
+
     - name: Compare files
-      run: diff -qr artifact artifact2
+      run: |
+        rm artifact/.hidden
+        diff -qr artifact artifact2
       shell: bash
 
     - name: Check for absence of symlinks
       run: if [ $(find artifact2 -type l | wc -l) != 0 ]; then echo "Symlinks found"; exit 1; fi
-      shell: bash
-
-    - name: Check for absence of hidden files
-      run: if [ $(find artifact2 -regex ".*/\..*" | wc -l) != 0 ]; then echo "Hidden files found"; exit 1; fi
       shell: bash

--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Compare files
       run: |
-        diff_output=$(diff -qr artifact artifact2 | grep -v -e '.hidden' -e 'subdir/.hidden_also')
+        diff_output=$(diff -qr artifact artifact2 | grep -v -e '.hidden')
         if [ -n "$diff_output" ]; then
           echo "Unexpected differences found:"
           echo "$diff_output"

--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -45,13 +45,7 @@ jobs:
       shell: bash
 
     - name: Compare files
-      run: |
-        diff_output=$(diff -qr artifact artifact2 | grep -v -e '.hidden')
-        if [ -n "$diff_output" ]; then
-          echo "Unexpected differences found:"
-          echo "$diff_output"
-          exit 1
-        fi
+      run: diff -qr artifact artifact2
       shell: bash
 
     - name: Check for absence of symlinks

--- a/.github/workflows/test-hosted-runners.yml
+++ b/.github/workflows/test-hosted-runners.yml
@@ -45,7 +45,13 @@ jobs:
       shell: bash
 
     - name: Compare files
-      run: diff -qr artifact artifact2
+      run: |
+        diff_output=$(diff -qr artifact artifact2 | grep -v -e '.hidden' -e 'subdir/.hidden_also')
+        if [ -n "$diff_output" ]; then
+          echo "Unexpected differences found:"
+          echo "$diff_output"
+          exit 1
+        fi
       shell: bash
 
     - name: Check for absence of symlinks

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,7 @@ runs:
           -cvf "$RUNNER_TEMP/artifact.tar" \
           --exclude=.git \
           --exclude=.github \
+          --exclude=".*" \
           .
         echo ::endgroup::
       env:
@@ -49,6 +50,7 @@ runs:
           -cvf "$RUNNER_TEMP/artifact.tar" \
           --exclude=.git \
           --exclude=.github \
+          --exclude=".*" \
           .
         echo ::endgroup::
       env:
@@ -66,6 +68,7 @@ runs:
           -cvf "$RUNNER_TEMP\artifact.tar" \
           --exclude=.git \
           --exclude=.github \
+          --exclude=".*" \
           --force-local \
           "."
         echo ::endgroup::

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
           -cvf "$RUNNER_TEMP/artifact.tar" \
           --exclude=.git \
           --exclude=.github \
-          --exclude=".*" \
+          --exclude=".[^/]*" \
           .
         echo ::endgroup::
       env:
@@ -50,7 +50,7 @@ runs:
           -cvf "$RUNNER_TEMP/artifact.tar" \
           --exclude=.git \
           --exclude=.github \
-          --exclude=".*" \
+          --exclude=".[^/]*" \
           .
         echo ::endgroup::
       env:
@@ -68,7 +68,7 @@ runs:
           -cvf "$RUNNER_TEMP\artifact.tar" \
           --exclude=.git \
           --exclude=.github \
-          --exclude=".*" \
+          --exclude=".[^/]*" \
           --force-local \
           "."
         echo ::endgroup::

--- a/script/new-artifact.sh
+++ b/script/new-artifact.sh
@@ -11,4 +11,3 @@ ln -s hello.txt bonjour.txt
 
 # Create some hidden files
 echo 'foo' > .hidden
-echo 'bar' > subdir/.hidden_also

--- a/script/new-artifact.sh
+++ b/script/new-artifact.sh
@@ -8,3 +8,7 @@ echo 'world' > subdir/world.txt
 # Add some symlinks (which we should dereference properly when archiving)
 ln -s subdir subdir-link
 ln -s hello.txt bonjour.txt
+
+# Create some hidden files
+echo 'foo' > .hidden
+echo 'bar' > subdir/.hidden_also


### PR DESCRIPTION
closes: https://github.com/github/pages-engineering/issues/5265

In the [upload-artifact](https://github.com/actions/upload-artifact) action it excludes hidden files that could lead to sensitive data. After talking with the actions team, even though we utilize this action at the very end we upload a `.tar` file https://github.com/actions/upload-pages-artifact/blob/1780dfc2cece65a782cc86fa133f96aef8ad0345/action.yml#L80. Hence, we need to exclude these files when we create the `.tar`.