### PR TITLE
Introduce support for the 'overwrite' option of upload-artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ jobs:
 | `name`           | `false`   | `github-pages` | Artifact name                                      |
 | `path`           | `true`    | `_site/`       | Path of the directory containing the static assets |
 | `retention-days` | `false`   | `1`            | Duration after which artifact will expire in days  |
+| `overwrite`      | `false`   | `false`        | Whther the artifact should overwrite existing ones |
 
 ### Outputs 📤
 

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: "Duration after which artifact will expire in days."
     required: false
     default: "1"
+  overwrite:
+    description: "If true, an artifact with a matching name will be deleted before a new one is uploaded. If false, the action will fail if an artifact for the given name already exists. Does not fail if the artifact does not exist."
+    required: false
+    default: 'false'
 outputs:
   artifact_id:
     description: "The ID of the artifact that was uploaded."
@@ -83,3 +87,4 @@ runs:
         path: ${{ runner.temp }}/artifact.tar
         retention-days: ${{ inputs.retention-days }}
         if-no-files-found: error
+        overwrite: ${{ inputs.overwrite }}


### PR DESCRIPTION
This patch allows the `overwrite` option to be passed to `upload-pages`. This is useful for workflows where `upload-pages-artifact` is invoked twice. Without the `overwrite` option, the upload fails the second time.

In my particular case, I run a workflow that consists in two parts, one that is quick and one that is long. I want to run `upload-pages-artifact` twice: once when the quick action is finished, and again when the longer one concludes. Thus, the page can be updated without waiting for the longer action to complete.

This patch would close #110 .