### PR TITLE
Pin `actions/upload-artifact` to SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - name: Upload artifact
       id: upload-artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/artifact.tar


### PR DESCRIPTION
👋 Updating `uses: actions/upload-artifact@v4`  in the composite action to pin to [`v4.6.2`](https://github.com/actions/upload-artifact/releases/tag/v4.6.2) SHA 