### PR TITLE
Hash pinning upload-artifact. Bringing hash pinning to this version i…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         INPUT_PATH: ${{ inputs.path }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # 3.1.3
       with:
         name: ${{ inputs.name }}
         path: ${{ runner.temp }}/artifact.tar


### PR DESCRIPTION
…s mandatory because higher revisions are currently not supported on GHES.

**Rationale**: my company is using GHES. upload-artifact@v4+ is  not supported on GHES. Therefore I must use upload-pages-artifact@v2, which uses actions/upload-artifact@v3. Unfortunately it does so without hash pinning, therefore I cannot use it.
My change aims at adding hash pinning.
See also:  https://github.com/actions/upload-artifact/issues/537

********** 
This change should be merged into a branch based on commit a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
********** 